### PR TITLE
don't import s3nb during setup.py

### DIFF
--- a/s3nb.py
+++ b/s3nb.py
@@ -21,7 +21,7 @@ from IPython.utils.traitlets import Unicode
 from IPython.utils import tz
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 # s3 return different time formats in different situations apparently
 S3_TIMEFORMAT_GET_KEY = '%a, %d %b %Y %H:%M:%S GMT'

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import s3nb
-
 setup(
     name = 's3nb',
-    version = s3nb.__version__,
+    version = '0.0.2',
     author = "Monetate Inc.",
     author_email = "graphaelli@monetate.com",
     description = "s3 backed notebook manager for ipython 2.0+",


### PR DESCRIPTION
In case install requirements are missing, preventing them from
being discovered.
