### PR TITLE
NameError if trailing delimiter is missing from the s3 path

### DIFF
--- a/s3nb.py
+++ b/s3nb.py
@@ -85,7 +85,7 @@ class S3NotebookManager(NotebookManager):
         self.s3_bucket, self.s3_prefix = self._parse_s3_uri(self.s3_base_uri, self.s3_key_delimiter)
         # ensure prefix ends with the delimiter
         if not self.s3_prefix.endswith(self.s3_key_delimiter):
-            self.s3_prefix += s3_key_delimiter
+            self.s3_prefix += self.s3_key_delimiter
         self.s3_connection = boto.connect_s3()
         self.bucket = self.s3_connection.get_bucket(self.s3_bucket)
 


### PR DESCRIPTION
Setting up a new remote server, I forgot the trailing slash on the s3 path. That threw a NameError when it goes down the branch that checks for the `s3_key_delimiter` on the end of the string and tries to append it:

```
  File "lib/python2.7/site-packages/s3nb.py", line 88, in __init__
    self.s3_prefix += s3_key_delimiter
NameError: global name 's3_key_delimiter' is not defined
```

This pull request fixes that. It's just missing the `self.`