### PR TITLE
ipy3 - Adjust dir_exists logic.

### DIFF
--- a/s3nb/ipy3.py
+++ b/s3nb/ipy3.py
@@ -201,16 +201,18 @@ class S3ContentsManager(ContentsManager):
             return model
 
     def dir_exists(self, path):
+        """Is ``path`` a directory?
+
+        :param str path: A path to test
+        :rtype: :py:class:`bool`
+        :returns: ``True`` if ``path`` is a directory.
+
+        """
         self.log.debug('dir_exists: %s', locals())
-        key = self._path_to_s3_key(path)
-        if path == '':
+        if not path:
             return True
-        else:
-            try:
-                next(iter(self.bucket.list(key, self.s3_key_delimiter)))
-                return True
-            except StopIteration:
-                return False
+        for key in self.bucket.list(self._path_to_s3_key(path), self.s3_key_delimiter):
+            return False if self.bucket.get_key(key.name) else True
 
     def is_hidden(self, path):
         self.log.debug('is_hidden %s', locals())


### PR DESCRIPTION
Make an extra S3 request to get a key returned from a bucket listing to determine if the key object in that list represents a prefix or a file.  The previous logic presented problems when attempting to access static files via a `IPython.display.FileLink` invocation because it was incorrectly returning a file as a directory type.
